### PR TITLE
add option for task workingdirectory

### DIFF
--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -9,7 +9,6 @@ Type=oneshot
 {% if task_workdir is defined and task_workdir and task_workdir|length %}
 WorkingDirectory={{ task_workdir }}
 {% endif %}
-
 {% if task_user is defined and task_user and task_user|length %}
 User={{ task_user }}
 {% endif %}

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -6,6 +6,10 @@ Description={{ task_description }}
 
 [Service]
 Type=oneshot
+{% if task_workdir is defined and task_workdir and task_workdir|length %}
+WorkingDirectory={{ task_workdir }}
+{% endif %}
+
 {% if task_user is defined and task_user and task_user|length %}
 User={{ task_user }}
 {% endif %}


### PR DESCRIPTION
Add the option to set the workingdirectory, this is needed to execute cc-ansible, among other context-dependent scripts.

See: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#WorkingDirectory=